### PR TITLE
scraping: change log from debug to warn on parse error

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1365,7 +1365,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	if appErr != nil {
 		app.Rollback()
 		app = sl.appender(sl.appenderCtx)
-		level.Debug(sl.l).Log("msg", "Append failed", "err", appErr)
+		level.Warn(sl.l).Log("msg", "Append failed", "err", appErr)
 		// The append failed, probably due to a parse error or sample limit.
 		// Call sl.append again with an empty scrape to trigger stale markers.
 		if _, _, _, err := sl.append(app, []byte{}, "", appendTime); err != nil {


### PR DESCRIPTION
In this PR, I have made a change to improve the logging of append failures in Prometheus. Previously, the log level for "Append failed" messages was set to Debug. 
However, since these failures can be crucial for users to understand potential issues with parsing or sample limits, I have raised the log level to Warning.